### PR TITLE
Add support for ExecTask and ExecTaskStreaming APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added changelog
 - Improve batch job and restart behavior (#30)
 - Add support for signals (#31)
+- Add support for exec (#32)
 
 ## [0.6.0] - 2020-02-17

--- a/driver/exec_utils.go
+++ b/driver/exec_utils.go
@@ -1,0 +1,287 @@
+// imported from:
+// https://github.com/hashicorp/nomad/tree/v1.3.3/drivers/shared/executor/exec_utils.go
+package pot
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	dproto "github.com/hashicorp/nomad/plugins/drivers/proto"
+)
+
+// execHelper is a convenient wrapper for starting and executing commands, and handling their output
+type execHelper struct {
+	logger hclog.Logger
+
+	// newTerminal function creates a tty appropriate for the command
+	// The returned pty end of tty function is to be called after process start.
+	newTerminal func() (pty func() (*os.File, error), tty *os.File, err error)
+
+	// setTTY is a callback to configure the command with slave end of the tty of the terminal, when tty is enabled
+	setTTY func(tty *os.File) error
+
+	// setTTY is a callback to configure the command with std{in|out|err}, when tty is disabled
+	setIO func(stdin io.Reader, stdout, stderr io.Writer) error
+
+	// processStart starts the process, like `exec.Cmd.Start()`
+	processStart func() error
+
+	// processWait blocks until command terminates and returns its final state
+	processWait func() (*os.ProcessState, error)
+}
+
+func (e *execHelper) run(ctx context.Context, tty bool, stream drivers.ExecTaskStream) error {
+	if tty {
+		return e.runTTY(ctx, stream)
+	}
+	return e.runNoTTY(ctx, stream)
+}
+
+func (e *execHelper) runTTY(ctx context.Context, stream drivers.ExecTaskStream) error {
+	ptyF, tty, err := e.newTerminal()
+	if err != nil {
+		return fmt.Errorf("failed to open a tty: %v", err)
+	}
+	defer tty.Close()
+
+	if err := e.setTTY(tty); err != nil {
+		return fmt.Errorf("failed to set command tty: %v", err)
+	}
+	if err := e.processStart(); err != nil {
+		return fmt.Errorf("failed to start command: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 3)
+
+	pty, err := ptyF()
+	if err != nil {
+		return fmt.Errorf("failed to get pty: %v", err)
+	}
+
+	defer pty.Close()
+	wg.Add(1)
+	go handleStdin(e.logger, pty, stream, errCh)
+	// when tty is on, stdout and stderr point to the same pty so only read once
+	go handleStdout(e.logger, pty, &wg, stream.Send, errCh)
+
+	ps, err := e.processWait()
+
+	// force close streams to close out the stream copying goroutines
+	tty.Close()
+
+	// wait until we get all process output
+	wg.Wait()
+
+	// wait to flush out output
+	stream.Send(cmdExitResult(ps, err))
+
+	select {
+	case cerr := <-errCh:
+		return cerr
+	default:
+		return nil
+	}
+}
+
+func (e *execHelper) runNoTTY(ctx context.Context, stream drivers.ExecTaskStream) error {
+	var sendLock sync.Mutex
+	send := func(v *drivers.ExecTaskStreamingResponseMsg) error {
+		sendLock.Lock()
+		defer sendLock.Unlock()
+
+		return stream.Send(v)
+	}
+
+	stdinPr, stdinPw := io.Pipe()
+	stdoutPr, stdoutPw := io.Pipe()
+	stderrPr, stderrPw := io.Pipe()
+
+	defer stdoutPw.Close()
+	defer stderrPw.Close()
+
+	if err := e.setIO(stdinPr, stdoutPw, stderrPw); err != nil {
+		return fmt.Errorf("failed to set command io: %v", err)
+	}
+
+	if err := e.processStart(); err != nil {
+		return fmt.Errorf("failed to start command: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 3)
+
+	wg.Add(2)
+	go handleStdin(e.logger, stdinPw, stream, errCh)
+	go handleStdout(e.logger, stdoutPr, &wg, send, errCh)
+	go handleStderr(e.logger, stderrPr, &wg, send, errCh)
+
+	ps, err := e.processWait()
+
+	// force close streams to close out the stream copying goroutines
+	stdinPr.Close()
+	stdoutPw.Close()
+	stderrPw.Close()
+
+	// wait until we get all process output
+	wg.Wait()
+
+	// wait to flush out output
+	stream.Send(cmdExitResult(ps, err))
+
+	select {
+	case cerr := <-errCh:
+		return cerr
+	default:
+		return nil
+	}
+}
+func cmdExitResult(ps *os.ProcessState, err error) *drivers.ExecTaskStreamingResponseMsg {
+	exitCode := -1
+
+	if ps == nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			ps = ee.ProcessState
+		}
+	}
+
+	if ps == nil {
+		exitCode = -2
+	} else if status, ok := ps.Sys().(syscall.WaitStatus); ok {
+		exitCode = status.ExitStatus()
+		if status.Signaled() {
+			const exitSignalBase = 128
+			signal := int(status.Signal())
+			exitCode = exitSignalBase + signal
+		}
+	}
+
+	return &drivers.ExecTaskStreamingResponseMsg{
+		Exited: true,
+		Result: &dproto.ExitResult{
+			ExitCode: int32(exitCode),
+		},
+	}
+}
+
+func handleStdin(logger hclog.Logger, stdin io.WriteCloser, stream drivers.ExecTaskStream, errCh chan<- error) {
+	for {
+		m, err := stream.Recv()
+		if isClosedError(err) {
+			return
+		} else if err != nil {
+			errCh <- err
+			return
+		}
+
+		if m.Stdin != nil {
+			if len(m.Stdin.Data) != 0 {
+				_, err := stdin.Write(m.Stdin.Data)
+				if err != nil {
+					errCh <- err
+					return
+				}
+			}
+			if m.Stdin.Close {
+				stdin.Close()
+			}
+		} else if m.TtySize != nil {
+			err := setTTYSize(stdin, m.TtySize.Height, m.TtySize.Width)
+			if err != nil {
+				errCh <- fmt.Errorf("failed to resize tty: %v", err)
+				return
+			}
+		}
+	}
+}
+
+func handleStdout(logger hclog.Logger, reader io.Reader, wg *sync.WaitGroup, send func(*drivers.ExecTaskStreamingResponseMsg) error, errCh chan<- error) {
+	defer wg.Done()
+
+	buf := make([]byte, 4096)
+	for {
+		n, err := reader.Read(buf)
+		// always send output first if we read something
+		if n > 0 {
+			if err := send(&drivers.ExecTaskStreamingResponseMsg{
+				Stdout: &dproto.ExecTaskStreamingIOOperation{
+					Data: buf[:n],
+				},
+			}); err != nil {
+				errCh <- err
+				return
+			}
+		}
+
+		// then process error
+		if isClosedError(err) {
+			if err := send(&drivers.ExecTaskStreamingResponseMsg{
+				Stdout: &dproto.ExecTaskStreamingIOOperation{
+					Close: true,
+				},
+			}); err != nil {
+				errCh <- err
+				return
+			}
+			return
+		} else if err != nil {
+			errCh <- err
+			return
+		}
+
+	}
+}
+
+func handleStderr(logger hclog.Logger, reader io.Reader, wg *sync.WaitGroup, send func(*drivers.ExecTaskStreamingResponseMsg) error, errCh chan<- error) {
+	defer wg.Done()
+
+	buf := make([]byte, 4096)
+	for {
+		n, err := reader.Read(buf)
+		// always send output first if we read something
+		if n > 0 {
+			if err := send(&drivers.ExecTaskStreamingResponseMsg{
+				Stderr: &dproto.ExecTaskStreamingIOOperation{
+					Data: buf[:n],
+				},
+			}); err != nil {
+				errCh <- err
+				return
+			}
+		}
+
+		// then process error
+		if isClosedError(err) {
+			if err := send(&drivers.ExecTaskStreamingResponseMsg{
+				Stderr: &dproto.ExecTaskStreamingIOOperation{
+					Close: true,
+				},
+			}); err != nil {
+				errCh <- err
+				return
+			}
+			return
+		} else if err != nil {
+			errCh <- err
+			return
+		}
+
+	}
+}
+
+func isClosedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return err == io.EOF ||
+		err == io.ErrClosedPipe ||
+		isUnixEIOErr(err)
+}

--- a/driver/prepare.go
+++ b/driver/prepare.go
@@ -288,3 +288,30 @@ func prepareSignal(cfg *drivers.TaskConfig, taskCfg TaskConfig, sig os.Signal) (
 
 	return se, nil
 }
+
+func prepareExec(cfg *drivers.TaskConfig, cmd[] string) (syexec, error) {
+	argv := make([]string, 0, 50)
+	var se syexec
+	se.cfg = cfg
+	se.env = cfg.EnvList()
+
+	// action can be run/exec
+
+	argv = append(argv, "exec")
+
+	if len(cmd) == 0 {
+		return se, fmt.Errorf("empty command passed to prepareExec")
+	}
+
+	parts := strings.Split(cfg.ID, "/")
+	completeName := parts[1] + "_" + parts[2] + "_" + parts[0]
+
+	argv = append(argv, "-p")
+	argv = append(argv, completeName)
+
+	argv = append(argv, cmd[:]...)
+
+	se.argvExec = argv
+
+	return se, nil
+}

--- a/driver/pty_unix.go
+++ b/driver/pty_unix.go
@@ -1,0 +1,44 @@
+// imported from:
+// https://github.com/hashicorp/nomad/tree/v1.3.3/drivers/shared/executor/pty_unix.go
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package pot
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/creack/pty"
+	"golang.org/x/sys/unix"
+)
+
+func sessionCmdAttr(tty *os.File) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setsid:  true,
+		Setctty: true,
+	}
+}
+
+func setTTYSize(w io.Writer, height, width int32) error {
+	f, ok := w.(*os.File)
+	if !ok {
+		return fmt.Errorf("attempted to resize a non-tty session")
+	}
+
+	return pty.Setsize(f, &pty.Winsize{
+		Rows: uint16(height),
+		Cols: uint16(width),
+	})
+
+}
+
+func isUnixEIOErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), unix.EIO.Error())
+}

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/Sirupsen/logrus v0.0.0-00010101000000-000000000000 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/appc/spec v0.8.11 // indirect
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e // indirect
 	github.com/checkpoint-restore/go-criu v0.0.0-20191125063657-fcdcd07065c5 // indirect
 	github.com/containerd/go-cni v0.0.0-20191121212822-60d125212faf // indirect
 	github.com/containernetworking/plugins v0.8.3 // indirect
 	github.com/coreos/go-iptables v0.4.3 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/creack/pty v1.1.18 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/docker/cli v0.0.0-20191202230238-13fb276442f5 // indirect
 	github.com/docker/docker v1.13.1 // indirect
@@ -42,6 +44,7 @@ require (
 	github.com/vbatts/tar-split v0.11.1 // indirect
 	github.com/zclconf/go-cty v1.1.1 // indirect
 	go4.org v0.0.0-20191010144846-132d2879e1e9 // indirect
+	golang.org/x/sys v0.0.0-20191115151921-52ab43148777 // indirect
 )
 
 // use lower-case sirupsen

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cyphar/filepath-securejoin v0.2.3-0.20190205144030-7efe413b52e1 h1:dCqRswe3ZAwkQWdvFLwRqmJCpGP3DWb7bFogdqY3+QU=


### PR DESCRIPTION
The ExecTask API allows running commands within a running pot
as part of service checks, example:

    service {
       check {
         type    = "script"
         command = "/bin/sh"
         args    = ["-c", "test -f /tmp/mycookie || exit 2"]
         interval = "10s"
         timeout = "5s"
       }
     }

The ExecTaskStreaming API allows running command within a pot
from the command line:

    nomad alloc exec 94b77f14 touch /tmp/mycookie
    nomad alloc -job myjob vi /etc/resolv.conf

This API also allows running commands and opening a shell using
the Nomad web UI.